### PR TITLE
Update pystout.py to use pd.concat() not append()

### DIFF
--- a/pystout/pystout.py
+++ b/pystout/pystout.py
@@ -374,7 +374,7 @@ Output:
             r = []
             for m in models:
                 r.append(trygetstat(key,m))
-            options = options.append(pd.DataFrame([r],index=[value]))
+            options = pd.concat([options,pd.DataFrame([r],index=[value])])
     else:
         options = pd.DataFrame()
 


### PR DESCRIPTION
Replaced line 377 to use pd.concat() instead of the original pd.append().  pd.append() is depreciated.

First time doing a pull request (!)